### PR TITLE
Hide touches view after disabling ShowTime

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -194,4 +194,21 @@ class Tests: XCTestCase {
     XCTAssertEqual(_touches.count, 1)
   }
     
+  func test_removingTouchViewsAfterDisabling() {
+    XCTAssertTrue(_touches.isEmpty)
+    
+    let defaultState = ShowTime.enabled
+    ShowTime.enabled = .always
+    
+    let window = UIWindow()
+    let startEvent = MockEvent(touches: [MockTouch(phase: .began)])
+    window.sendEvent(startEvent)
+    ShowTime.enabled = .never
+    let endEvent = MockEvent(touches: [MockTouch(phase: .ended)])
+    window.sendEvent(endEvent)
+    
+    XCTAssertTrue(_touches.isEmpty)
+    ShowTime.enabled = defaultState
+  }
+    
 }

--- a/ShowTime.swift
+++ b/ShowTime.swift
@@ -161,14 +161,10 @@ extension UIWindow {
   
   @objc private func swizzled_sendEvent(_ event: UIEvent) {
     self.swizzled_sendEvent(event)
-    
     guard ShowTime.shouldEnable else {
-        for touch in _touches.keys {
-            hideTouchView(associatedWith: touch)
-        }
+        removeAllTouchViews()
         return
     }
-    
     event.allTouches?.forEach {
       if ShowTime.shouldIgnoreApplePencilEvents && $0.isApplePencil { return }
       switch $0.phase {
@@ -191,10 +187,16 @@ extension UIWindow {
   }
   
   private func touchEnded(_ touch: UITouch) {
-    hideTouchView(associatedWith: touch)
+    removeTouchView(associatedWith: touch)
   }
     
-  private func hideTouchView(associatedWith touch: UITouch) {
+  private func removeAllTouchViews() {
+    _touches.keys.forEach { touch in
+        removeTouchView(associatedWith: touch)
+    }
+  }
+    
+  private func removeTouchView(associatedWith touch: UITouch) {
     guard let touchView = _touches[touch] else { return }
     touchView.disappear()
     _touches[touch] = nil

--- a/ShowTime.swift
+++ b/ShowTime.swift
@@ -161,7 +161,14 @@ extension UIWindow {
   
   @objc private func swizzled_sendEvent(_ event: UIEvent) {
     self.swizzled_sendEvent(event)
-    guard ShowTime.shouldEnable else { return }
+    
+    guard ShowTime.shouldEnable else {
+        for touch in _touches.keys {
+            hideTouchView(associatedWith: touch)
+        }
+        return
+    }
+    
     event.allTouches?.forEach {
       if ShowTime.shouldIgnoreApplePencilEvents && $0.isApplePencil { return }
       switch $0.phase {
@@ -184,11 +191,14 @@ extension UIWindow {
   }
   
   private func touchEnded(_ touch: UITouch) {
+    hideTouchView(associatedWith: touch)
+  }
+    
+  private func hideTouchView(associatedWith touch: UITouch) {
     guard let touchView = _touches[touch] else { return }
     touchView.disappear()
     _touches[touch] = nil
   }
-  
 }
 
 fileprivate extension UITouch {


### PR DESCRIPTION
When we changing ShowTime enable mode to `.never` active touch views stays on the screen. The request contains fix.