### PR TITLE
Fix exhaustive switch complain in XCode 11.4

### DIFF
--- a/ShowTime.swift
+++ b/ShowTime.swift
@@ -212,7 +212,7 @@ extension UIWindow {
             case .began: touchBegan($0)
             case .moved, .stationary: touchMoved($0)
             case .cancelled, .ended: touchEnded($0)
-            default: return
+            @unknown default: return
             }
         }
     }

--- a/ShowTime.swift
+++ b/ShowTime.swift
@@ -212,6 +212,7 @@ extension UIWindow {
             case .began: touchBegan($0)
             case .moved, .stationary: touchMoved($0)
             case .cancelled, .ended: touchEnded($0)
+            default: return
             }
         }
     }


### PR DESCRIPTION
As of this project, there's no need for handling
newly introduced region related cases.
So, better to just ignore the newly introduced cases entirely.

@available(iOS 13.4, *)
case regionEntered = 5

@available(iOS 13.4, *)
case regionMoved = 6

 @available(iOS 13.4, *)
 case regionExited = 7